### PR TITLE
Replaced pkg_resources with importlib

### DIFF
--- a/m2r3/m2r2.py
+++ b/m2r3/m2r2.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, unicode_literals
 import mistune
-from pkg_resources import get_distribution
+import importlib.metadata as meta
 from .constants import PROLOG
 from .rst_parser import RestBlockParser, RestInlineParser
 from .rst_renderer import RestRenderer
 
-__version__ = get_distribution("m2r3").version
+__version__ = meta.version("m2r3")
 
 class M2R(mistune.Markdown):
     def __init__(self, renderer=None, block=None, inline=None, plugins=None):


### PR DESCRIPTION
pkg_resources was deprecated and is now not a thing (at least according to PDM), so this import breaks.

I have a bunch of projects that depend on m2r2, so it would be great if you could get this patch published soon. Otherwise I have to create a m2r4 pip package with this change, and that is obnoxious.